### PR TITLE
feat: 도메인 설계

### DIFF
--- a/src/main/java/com/findbugs/findbugstaff/FindBugsStaffApplication.java
+++ b/src/main/java/com/findbugs/findbugstaff/FindBugsStaffApplication.java
@@ -2,8 +2,12 @@ package com.findbugs.findbugstaff;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
+@EnableJpaAuditing
+@EnableJpaRepositories
 public class FindBugsStaffApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/findbugs/findbugstaff/domain/Address.java
+++ b/src/main/java/com/findbugs/findbugstaff/domain/Address.java
@@ -1,0 +1,16 @@
+package com.findbugs.findbugstaff.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor
+@Getter
+public class Address {
+    private String region_1depth;   // 지역명 1
+    private String region_2depth;   // 지역명 2
+    private String region_3depth;   // 지역명 3
+    private String street_name;     // 도로명
+    private String detail_address;  // 세부주소
+}

--- a/src/main/java/com/findbugs/findbugstaff/domain/BaseEntity.java
+++ b/src/main/java/com/findbugs/findbugstaff/domain/BaseEntity.java
@@ -1,0 +1,32 @@
+package com.findbugs.findbugstaff.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SuperBuilder
+@Jacksonized
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/findbugs/findbugstaff/domain/Bug.java
+++ b/src/main/java/com/findbugs/findbugstaff/domain/Bug.java
@@ -1,0 +1,34 @@
+package com.findbugs.findbugstaff.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SuperBuilder
+@Jacksonized
+@Getter
+public class Bug {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "bug_id")
+    private Long id;
+
+    private String name;
+
+    private String description;
+
+    /*
+    벌레 상세 정보는 NoSQL을 통해 관리
+     */
+}

--- a/src/main/java/com/findbugs/findbugstaff/domain/Camera.java
+++ b/src/main/java/com/findbugs/findbugstaff/domain/Camera.java
@@ -1,0 +1,32 @@
+package com.findbugs.findbugstaff.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SuperBuilder
+@Jacksonized
+@Getter
+public class Camera {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "camera_id")
+    private Long id;
+
+    private Long cameraSerialId;
+
+    private String cameraName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+}

--- a/src/main/java/com/findbugs/findbugstaff/domain/DetectionHistory.java
+++ b/src/main/java/com/findbugs/findbugstaff/domain/DetectionHistory.java
@@ -1,0 +1,43 @@
+package com.findbugs.findbugstaff.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SuperBuilder
+@Jacksonized
+@Getter
+public class DetectionHistory {
+    @Id
+    @GeneratedValue
+    @Column(name = "detection_history_id")
+    private Long id;
+
+    private String imageUrl;
+
+    private String detectedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "camera_id")
+    private Camera camera;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bug_id")
+    private Bug bug;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "visit_id")
+    private Visit visit;
+
+}

--- a/src/main/java/com/findbugs/findbugstaff/domain/Member.java
+++ b/src/main/java/com/findbugs/findbugstaff/domain/Member.java
@@ -1,0 +1,40 @@
+package com.findbugs.findbugstaff.domain;
+
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SuperBuilder
+@Jacksonized
+@Getter
+public class Member {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "member_id")
+    private Long id;
+
+    private String name;
+    private String email;
+    private String phoneNumber;
+
+    @Embedded
+    private Address address;
+
+    private String membership;
+
+    private LocalDateTime registerAt;
+
+    private LocalDateTime expiresAt;
+
+}

--- a/src/main/java/com/findbugs/findbugstaff/domain/Notification.java
+++ b/src/main/java/com/findbugs/findbugstaff/domain/Notification.java
@@ -1,0 +1,32 @@
+package com.findbugs.findbugstaff.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SuperBuilder
+@Jacksonized
+@Getter
+public class Notification {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "notification_id")
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "staff_id")
+    private Staff staff;
+
+}

--- a/src/main/java/com/findbugs/findbugstaff/domain/Staff.java
+++ b/src/main/java/com/findbugs/findbugstaff/domain/Staff.java
@@ -1,0 +1,44 @@
+package com.findbugs.findbugstaff.domain;
+
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SuperBuilder
+@Jacksonized
+@Getter
+public class Staff extends BaseEntity{
+
+    @Id
+    @GeneratedValue
+    @Column(name = "staff_id")
+    private Long id;
+
+    private String name;
+
+    private String position;
+
+    private String phoneNumber;
+
+    @Embedded
+    private Address territory;
+
+//    @Embedded
+//    @AttributeOverrides({
+//            @AttributeOverride(name = "region_1depth", column=@Column(name="staff_region_1depth")),
+//            @AttributeOverride(name = "region_2depth", column=@Column(name="staff_region_2depth")),
+//            @AttributeOverride(name = "region_3depth", column=@Column(name="staff_region_3depth")),
+//            @AttributeOverride(name = "street_name",   column=@Column(name="staff_street_name")),
+//            @AttributeOverride(name = "detail",        column=@Column(name="staff_detail_address"))
+//    })
+//    private Address address;
+
+}

--- a/src/main/java/com/findbugs/findbugstaff/domain/Visit.java
+++ b/src/main/java/com/findbugs/findbugstaff/domain/Visit.java
@@ -1,6 +1,5 @@
 package com.findbugs.findbugstaff.domain;
 
-
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -17,29 +16,29 @@ import java.time.LocalDateTime;
 @SuperBuilder
 @Jacksonized
 @Getter
-public class Member {
+public class Visit extends BaseEntity{
 
     @Id
     @GeneratedValue
-    @Column(name = "member_id")
+    @Column(name = "visit_id")
     private Long id;
 
-    private String name;
-    private String email;
-    private String phoneNumber;
+    private LocalDateTime visitedAt;
 
-    @Embedded
-    private Address address;
+    /**
+     * 정기 점검, 방역 후 점검, 긴급 요청 방역
+     */
+    private String visitPurpose;
 
-    private String membership;
-
-    private LocalDateTime registerAt;
-
-    private LocalDateTime expiresAt;
+    private String visitComment;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "staff_id")
     private Staff manager;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
 
 
 


### PR DESCRIPTION
## 요약 및 목적

> 1차 DB 설계를 바탕으로 엔티티 설계를 완료했습니다.

![1차 DB](https://github.com/user-attachments/assets/5671c0e9-fab4-45e7-a4ee-d055179b791e)


## 변경 사항에 대한 설명

[C7A2B23](https://github.com/HSU-FindBugs/StaffApp-Backend/commit/c7a2b23410c5864348956769d4e057ec93a2613f)
+ 직원 엔티티 구현
+ Embedded Type 주소(Address) 구현
+ BaseEntity 구현 (DBA의 테이블의 수명주기 추적을 위함)

[5AD5A05](https://github.com/HSU-FindBugs/StaffApp-Backend/commit/5ad5a05bac2b8ab2aa4aa1464accb92260419114)
+ 고객 엔티티 구현

[88B176B](https://github.com/HSU-FindBugs/StaffApp-Backend/commit/88b176b92c447cd44354e7596a59155492adb4cd)
+ 방문 엔티티 구현
+ 멤버 엔티티와 Staff 엔티티 간 관계 구성
+ 방문 목적에 대한 변수명 추가 (기획자와 추후 논의할 필요 있습니다)

[52A3578](https://github.com/HSU-FindBugs/StaffApp-Backend/commit/52a3578e3989e41de555484c8de73174f34865bf)
+ 카메라 엔티티 구현
+ 추가적인 기능은 기획이 추가된 후 추가할 계획

[341B857](https://github.com/HSU-FindBugs/StaffApp-Backend/commit/341b857482c20bd18e1b7f93cbc073dc8e00accd)
+ 벌레 엔티티 구현
+ 벌레에 대한 상세 정보는 NoSQL을 통해 관리할 계획

[BDAEDE8](https://github.com/HSU-FindBugs/StaffApp-Backend/commit/bdaede80f7f5205f22631a20c0df151224a03509)
+ 탐지 기록 엔티티 구현
+ 탐지 기록를 입력할 서버에 대해 다시 논의할 필요가 있습니다.

[DEA82D9](https://github.com/HSU-FindBugs/StaffApp-Backend/commit/dea82d9e11b5003034971e42fb5290bf17e874bd)
+ 공지 엔티티 구현


